### PR TITLE
Fix incorrect indention in yaml template

### DIFF
--- a/src/configs/kcare-nexpose.yml.template
+++ b/src/configs/kcare-nexpose.yml.template
@@ -29,7 +29,7 @@ patch-server:
   # URL to connect with Kernelcare ePortal
   # For kernelcare ePortal use "http://<kernel-care-eportal-domain-name-or-ip>/admin/api/kcare/patchset/"
   # For original server use "https://cln.cloudlinux.com/api/kcare/patchset/"
-   server: https://cln.cloudlinux.com/api/kcare/patchset/
+  server: https://cln.cloudlinux.com/api/kcare/patchset/
 
   # Server for patch sets
   # For patch sets from server Kernelcare ePortal use domain name


### PR DESCRIPTION
Fix incorrect indention in the kcare-nexpose.yml.template